### PR TITLE
Delete the Windows debug files from the Jar to reduce the Jar size by about 30MB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,6 +176,14 @@ shadowJar {
 	archiveVersion.set('')
 	zip64 true
 	mergeServiceFiles()
+
+	exclude '**/*.pdb'  
+
+	eachFile { file ->
+		if (file.path.endsWith('.pdb')) {
+			file.exclude()
+		}
+	}
 }
 jar {
 	jar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE


### PR DESCRIPTION
Delete the Windows debug files from the Jar to reduce the Jar size by about 30MB