### PR TITLE
Update README - Build instructions for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ git submodule update --init --recursive
 bash build.sh
 ```
 
-# Build (Mac OS)
+# Build (macOS)
 ```
 git clone https://github.com/CommonWealthRobotics/CaDoodle-Application.git
 


### PR DESCRIPTION
Build was easy to figure out but there are no specific instructions for MacOS in the README

Few tweaks to the readme:
- No need to run a second git submodule update, the latest is already pulled down in the first command
- MacOS specific instructions, same as linux just running `buildMac.sh` instead