### PR TITLE
Introduce `nix develop` reproducible environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ bowler
 **~
 /CSGdatabase.json
 **-autosave.kra
+
+# Isolated GRADLE_USER_HOME for `nix develop` reproducible environment
+.gradle-nix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775710090,
+        "narHash": "sha256-ar3rofg+awPB8QXDaFJhJ2jJhu+KqN/PRCXeyuXR76E=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "CaDoodle development shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        jdk = pkgs.zulu21;
+        openjfx = pkgs.openjfx;
+        gradleJavafxInit = pkgs.writeText "cadoodle-javafx-init.gradle" ''
+          allprojects {
+            plugins.withId('java') {
+              dependencies {
+                implementation files(
+                  '${openjfx}/modules/javafx.base',
+                  '${openjfx}/modules/javafx.controls',
+                  '${openjfx}/modules/javafx.fxml',
+                  '${openjfx}/modules/javafx.graphics',
+                  '${openjfx}/modules/javafx.media',
+                  '${openjfx}/modules/javafx.swing',
+                  '${openjfx}/modules/javafx.web'
+                )
+              }
+            }
+          }
+        '';
+        javafxNativeLibs = [
+          "${openjfx}/modules_libs/javafx.base"
+          "${openjfx}/modules_libs/javafx.graphics"
+          "${openjfx}/modules_libs/javafx.media"
+        ];
+        runtimeLibs = with pkgs; [
+          alsa-lib
+          ffmpeg
+          gtk2
+          gtk3
+          libGL
+          libx11
+          libxext
+          libxi
+          libxrandr
+          libxrender
+          libxtst
+          libxxf86vm
+          pango
+        ];
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            jdk
+            git
+            openjfx
+            wget
+            zip
+            xorg-server
+          ] ++ runtimeLibs;
+
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeLibs
+            + ":"
+            + pkgs.lib.concatStringsSep ":" javafxNativeLibs;
+
+          shellHook = ''
+            export JAVA_HOME="${jdk}"
+            export PATH="$JAVA_HOME/bin:$PATH"
+            export GRADLE_USER_HOME="$PWD/.gradle-nix"
+            mkdir -p "$GRADLE_USER_HOME/init.d"
+            ln -sfn "${gradleJavafxInit}" "$GRADLE_USER_HOME/init.d/cadoodle-javafx-init.gradle"
+
+            echo "CaDoodle dev shell ready"
+            echo "Run: git submodule update --init --recursive"
+            echo "Then: ./gradlew run"
+          '';
+        };
+      });
+}


### PR DESCRIPTION
Developers with Nix installed (on any Linux system, not just NixOS) can now run `nix develop` to instantly get an environment that will build and run CaDoodle, regardless of what is installed on the host. We hit some snags with OpenJFX but it seems to be working fine on my NixOS system.