### PR TITLE
Fixing exception / new doodle tree clearing

### DIFF
--- a/src/main/java/com/commonwealthrobotics/ComponentTreePanel.java
+++ b/src/main/java/com/commonwealthrobotics/ComponentTreePanel.java
@@ -560,11 +560,28 @@ public class ComponentTreePanel implements ICaDoodleStateUpdate {
 	}
 
 	@Override
-	public void onInitializationDone() {
+	public void onInitializationStart() {
+		BowlerStudio.runLater(() -> {
+			rootLabel = "Project";
+			rebuilding = true;
+			try {
+				root.getChildren().clear();
+			} finally {
+				rebuilding = false;
+			}
+			treeView.refresh();
+		});
 	}
 
 	@Override
-	public void onInitializationStart() {
+	public void onInitializationDone() {
+		BowlerStudio.runLater(() -> {
+			CaDoodleFile file = ap.get();
+			rootLabel = file.getMyProjectName() != null && !file.getMyProjectName().isBlank()
+					? file.getMyProjectName()
+					: "Project";
+			treeView.refresh();
+		});
 	}
 
 	@Override

--- a/src/main/java/com/commonwealthrobotics/ComponentTreePanel.java
+++ b/src/main/java/com/commonwealthrobotics/ComponentTreePanel.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.commonwealthrobotics.controls.SelectionSession;
+import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
@@ -94,10 +95,10 @@ public class ComponentTreePanel implements ICaDoodleStateUpdate {
 		treeView.setCellFactory(tv -> new ComponentTreeCell());
 		treeView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 		treeView.getStyleClass().add("component-tree-view");
-		session.addSelectionListener(() -> BowlerStudio.runLater(() -> {
+		session.addSelectionListener(() -> Platform.runLater(() -> BowlerStudio.runLater(() -> {
 			syncTreeSelectionFromSession();
 			treeView.refresh();
-		}));
+		})));
 
 		treeView.focusedProperty().addListener((obs, old, focused) -> treeView.refresh());
 


### PR DESCRIPTION
This pull request updates the `ComponentTreePanel` class to improve UI thread handling and clarify the initialization lifecycle. The main changes involve switching to JavaFX's `Platform.runLater` for thread safety.

**UI Thread Handling:**
* Wrapped selection listener updates in `Platform.runLater` to ensure UI operations are executed on the JavaFX Application Thread, improving thread safety. [[1]](diffhunk://#diff-38251551732995b3767127babc47bb497d02eb19a4cab60b28b5333b6c705442R13) [[2]](diffhunk://#diff-38251551732995b3767127babc47bb497d02eb19a4cab60b28b5333b6c705442L97-R101)

**Initialization Lifecycle Improvements:**
* Swapped the logic between `onInitializationStart` and `onInitializationDone` to better reflect their intended purposes: `onInitializationStart` now resets the tree and label, while `onInitializationDone` sets the project name and refreshes the tree. Both methods now use `BowlerStudio.runLater` for UI updates.